### PR TITLE
Re encode metadata

### DIFF
--- a/config/initializers/shrine.rb
+++ b/config/initializers/shrine.rb
@@ -6,7 +6,7 @@ Shrine.plugin :activerecord
 Shrine.plugin :logging, logger: Rails.logger
 Shrine.plugin :validation_helpers
 
-storage_location = if Rails.env.development?
+storage_location = if Rails.env.production?
                      Shrine::Storage::S3.new(
                          access_key_id: Rails.application.secrets.aws_access_key_id,
                          secret_access_key: Rails.application.secrets.aws_secret_access_key,

--- a/config/initializers/shrine.rb
+++ b/config/initializers/shrine.rb
@@ -6,7 +6,7 @@ Shrine.plugin :activerecord
 Shrine.plugin :logging, logger: Rails.logger
 Shrine.plugin :validation_helpers
 
-storage_location = if Rails.env.production?
+storage_location = if Rails.env.development?
                      Shrine::Storage::S3.new(
                          access_key_id: Rails.application.secrets.aws_access_key_id,
                          secret_access_key: Rails.application.secrets.aws_secret_access_key,


### PR DESCRIPTION
Before, re-uploading the same file would change its metadata and upload it as a new file.  This would break anything pointing to the old URL since the new file would be in a new URL.  This fix will upload the new file to the existing URL.