### PR TITLE
Bugfix updating filename

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -41,8 +41,8 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   # disabling logger speeds up tests
-  # unless ENV['RAILS_ENABLE_TEST_LOG']
-  #   config.logger = Logger.new(nil)
-  #   config.log_level = :fatal
-  # end
+  unless ENV['RAILS_ENABLE_TEST_LOG']
+    config.logger = Logger.new(nil)
+    config.log_level = :fatal
+  end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -41,8 +41,8 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   # disabling logger speeds up tests
-  unless ENV['RAILS_ENABLE_TEST_LOG']
-    config.logger = Logger.new(nil)
-    config.log_level = :fatal
-  end
+  # unless ENV['RAILS_ENABLE_TEST_LOG']
+  #   config.logger = Logger.new(nil)
+  #   config.log_level = :fatal
+  # end
 end

--- a/spec/requests/audios_controller_spec.rb
+++ b/spec/requests/audios_controller_spec.rb
@@ -28,6 +28,12 @@ describe Api::V1::AudiosController do
     end
 
     context 'when a last chunk is received' do
+      before(:each) do
+        allow(File).to receive(:size)
+        allow(File).to receive(:exists?).and_return(true)
+        allow(File).to receive(:open).and_call_original
+        allow(File).to receive(:open).with('tmp/final/lalala.wav.flac')
+      end
       ActiveJob::Base.queue_adapter = :test
       test_file = 'test.wav'
       file = Rack::Test::UploadedFile.new(Rails.root.join('spec', 'requests', test_file), 'audio/wav')
@@ -35,11 +41,6 @@ describe Api::V1::AudiosController do
       filename = 'lalala.wav'
 
       it 'enqueues a job and creates a new audio object' do
-        allow(File).to receive(:size)
-        allow(File).to receive(:exists?).and_return(true)
-        allow(File).to receive(:open).and_call_original
-        allow(File).to receive(:open).with('tmp/final/lalala.wav.flac')
-
         expect {
         post AUDIO_API_ENDPOINT, params: {file: file,
                                           flowTotalChunks: 2,
@@ -55,11 +56,6 @@ describe Api::V1::AudiosController do
       end
 
       it 'updates the non-unique fields' do
-        allow(File).to receive(:size)
-        allow(File).to receive(:exists?).and_return(true)
-        allow(File).to receive(:open).and_call_original
-        allow(File).to receive(:open).with('tmp/final/lalala.wav.flac')
-
         changed_contributor = 'ben stein'
         changed_title = 'lalad'
 
@@ -86,11 +82,6 @@ describe Api::V1::AudiosController do
       end
 
       it "updates existing audio's filename instead of creating a new audio" do
-        allow(File).to receive(:size)
-        allow(File).to receive(:exists?).and_return(true)
-        allow(File).to receive(:open).and_call_original
-        allow(File).to receive(:open).with('tmp/final/lalala.wav.flac')
-
         og_filename = 'originalfile.wav'
         new_filename = 'new_filename.wav'
         audio = Audio.create(

--- a/spec/requests/audios_controller_spec.rb
+++ b/spec/requests/audios_controller_spec.rb
@@ -84,6 +84,34 @@ describe Api::V1::AudiosController do
         expect(audio.contributors).to eq(changed_contributor)
 
       end
+
+      fit "updates existing audio's filename instead of creating a new audio" do
+        allow(File).to receive(:size)
+        allow(File).to receive(:exists?).and_return(true)
+        allow(File).to receive(:open).and_call_original
+        allow(File).to receive(:open).with('tmp/final/lalala.wav.flac')
+
+        originalFilename = 'filename233.wav'
+        audio = Audio.create(
+            title: 'no hiking for me',
+            filename: originalFilename,
+            uploader: @uploader
+        )
+
+        expect{
+          post AUDIO_API_ENDPOINT, params: {file: file,
+                                          flowTotalChunks: 2,
+                                          flowIdentifier: '123-lalala1',
+                                          flowFilename: filename,
+                                          title: 'title',
+                                          contributors: 'contributor',
+                                          originalFilename: originalFilename
+                                          }
+        }.not_to change{Audio.count}
+
+        expect(audio.filename).to eq(filename)
+      end
+
     end
   end
 

--- a/spec/requests/audios_controller_spec.rb
+++ b/spec/requests/audios_controller_spec.rb
@@ -85,16 +85,17 @@ describe Api::V1::AudiosController do
 
       end
 
-      fit "updates existing audio's filename instead of creating a new audio" do
+      it "updates existing audio's filename instead of creating a new audio" do
         allow(File).to receive(:size)
         allow(File).to receive(:exists?).and_return(true)
         allow(File).to receive(:open).and_call_original
         allow(File).to receive(:open).with('tmp/final/lalala.wav.flac')
 
-        originalFilename = 'filename233.wav'
+        og_filename = 'originalfile.wav'
+        new_filename = 'new_filename.wav'
         audio = Audio.create(
             title: 'no hiking for me',
-            filename: originalFilename,
+            filename: og_filename,
             uploader: @uploader
         )
 
@@ -102,14 +103,14 @@ describe Api::V1::AudiosController do
           post AUDIO_API_ENDPOINT, params: {file: file,
                                           flowTotalChunks: 2,
                                           flowIdentifier: '123-lalala1',
-                                          flowFilename: filename,
+                                          flowFilename: new_filename,
                                           title: 'title',
                                           contributors: 'contributor',
-                                          originalFilename: originalFilename
+                                          originalFilename: og_filename
                                           }
         }.not_to change{Audio.count}
-
-        expect(audio.filename).to eq(filename)
+        audio.reload
+        expect(audio.filename).to eq(new_filename)
       end
 
     end


### PR DESCRIPTION
The server-side fix for https://github.com/ProjectResound/planning/issues/105

If the client is replacing a file from the individual audio page, then we also send along the originalFilename so that the api will know to replace the primary key `filename` with the new file name instead of trying to create a new object.
