### PR TITLE
Makes requests to /api return 200 if it doesn't match any other route

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,8 @@ machine:
   environment:
     POSTGRES_TEST_URL: postgres://ubuntu@localhost:5432/circle_ruby_test
     SECRET_KEY_BASE: wallawallawashington
+    ALLOWED_CORS_URL: http://localhost:8000
+
 
 database:
   override:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,5 +16,9 @@ Rails.application.routes.draw do
   mount Resque::Server.new, at: '/resque'
   mount ActionCable.server => '/cable'
 
+  # Requests to /api that don't match any of the routes above should return a 200 for health checks.
+  get :api, to: proc { [200, {}, ['']] }
+
+  # Anything else, 404
   root to: 'errors#not_found'
 end

--- a/spec/requests/apis_controller_spec.rb
+++ b/spec/requests/apis_controller_spec.rb
@@ -1,0 +1,6 @@
+describe Api do
+  it 'returns 200' do
+    get '/api'
+    expect(response).to have_http_status(200)
+  end
+end

--- a/spec/routes_spec.rb
+++ b/spec/routes_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Routes', type: :routing do
   it 'routes audio searches' do
-    expect(:get => "/api/v1/audios/search?q=some-searchquery").to route_to(
+    expect(get: "/api/v1/audios/search?q=some-searchquery").to route_to(
                                                                      :controller => "api/v1/audios",
                                                                      :action => "search",
                                                                      :q => "some-searchquery")


### PR DESCRIPTION
Fix for: https://github.com/ProjectResound/planning/issues/119

Before this change, any non-valid or unauthenticated request would return a 404. This was breaking my AWS target group health check, since the target group makes a request to /api and expects a 200.  To get around this, I needed to manually update the health check to 404, which is a pain.  In hindsight, let's just return an empty response with 200 when a request comes in on /api and we can't match it to any of the existing routes.