### PR TITLE
Bugfixes the case when the user profile doesn't return a nickname

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -4,11 +4,17 @@ module Api::V1
 
     def create
       if profile = JWT.decode(JSON.parse(request.body.read)['idToken'], nil, false)[0]
-        User.find_or_create_by(uid: profile['sub']) do |user|
-          user.nickname = profile['nickname']
+        if profile['nickname']
+          User.find_or_create_by(uid: profile['sub']) do |user|
+            user.nickname = profile['nickname']
+          end
+          render status: :ok
+        else
+          raise "Could not create a user without a nickname"
         end
+      else
+        raise "Could not create a user"
       end
-      render status: :ok
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,8 +6,7 @@ class User < ApplicationRecord
   acts_as_paranoid
 
   has_many :audios,
-           foreign_key: 'uploader_id',
-           dependent: :destroy
+           foreign_key: 'uploader_id'
 
   self.primary_key = 'uid'
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe User, type: :model do
   context "destroy()" do
     it "does not destroy user's Audio" do
       user = User.create(uid: 'userid', nickname: 'nickname')
-      audio = Audio.create(title: 'hello world', uploader: user)
+      Audio.create!(title: 'hello world', uploader: user, filename: 'woohoo boohoo')
 
       expect {
         user.destroy
@@ -12,7 +12,7 @@ RSpec.describe User, type: :model do
     end
 
     it "does not return the deleted user" do
-      user = User.create(uid: 'userid', nickname: 'nickname')
+      user = User.create!(uid: 'userid', nickname: 'nickname')
 
       expect {
         user.destroy

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -21,6 +21,19 @@ describe Api::V1::UsersController do
       end
     end
 
+    context 'no nickname' do
+      it 'returns an error' do
+        uid = 'auth0|someId123123'
+        allow(JWT).to receive(:decode).and_return([{'sub' => uid}])
+
+        expect {
+          post USERS_API_ENDPOINT, params: { idToken: 'idtoken'}.to_json
+        }.to raise_error(RuntimeError)
+
+        expect(User.find_by_uid(uid)).to be_nil
+      end
+    end
+
     context 'a returning user' do
       it 'does not create a new user' do
         nickname = 'jamie.bond'


### PR DESCRIPTION
* This is to address an error where the client-side authentication wasn't requesting a profile scope and therefore not getting any nickname.  In this case, it would create a User without a nickname, which broke a lot of things.
* Instead of creating that invalid user, just avoid creating a user and return an error.
* Adds test for that.