### PR TITLE
Bugfix for reinstating a deleted user

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -7,9 +7,7 @@ module Api::V1
       raise "Could not create a user" if profile.nil?
 
       if profile['nickname']
-          User.find_or_create_by(uid: profile['sub']) do |user|
-            user.nickname = profile['nickname']
-          end
+          User.find_or_create_by_uid(uid: profile['sub'], nickname: profile['nickname'])
           render status: :ok
       else
         raise "Could not create a user without a nickname"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,8 +9,20 @@ class User < ApplicationRecord
            foreign_key: 'uploader_id'
 
   validates :nickname, presence: true
+  validates :uid, uniqueness: true
 
   self.primary_key = 'uid'
+
+  def self.find_or_create_by_uid(uid: uid, nickname: nickname)
+    if deleted_user = User.only_deleted.where(uid: uid).first
+      deleted_user.recover
+      deleted_user.nickname = nickname
+      return deleted_user
+    end
+    return User.create(uid: uid, nickname: nickname)
+  end
+
+  private
 
   def to_s
     "#<User uid:#{uid}, nickname: \"#{nickname}\">"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,8 +16,31 @@ RSpec.describe User, type: :model do
 
       expect {
         user.destroy
-      }.to change{ User.count }.by(-1)
+      }.to change(User, 'count').by(-1)
       expect(User.find_by_uid(user.uid)).to be(nil)
+    end
+  end
+
+  context "find_or_create_by_uid" do
+    it "does not create a new user if that uid has been deleted" do
+      create_params = {uid: 'uid', nickname: 'nick'}
+      user = User.find_or_create_by_uid(create_params)
+      user.destroy
+      created = nil
+
+      expect {
+        created = User.find_or_create_by_uid(create_params)
+      }.to_not change{User.with_deleted.count}
+      expect(created).to eq(user)
+    end
+
+    it "creates a new user" do
+      user = nil
+      create_params = {uid: 'uid', nickname: 'nick'}
+      expect {
+        user = User.find_or_create_by_uid(create_params)
+      }.to change{User.with_deleted.count}.by(1)
+      expect(user).to_not be(nil)
     end
   end
 end


### PR DESCRIPTION
When a user is deleted, they are not actually deleted. Their user object is hidden by the acts_as_paranoid gem. When the same user tries to re-create their account, there was a bug where we were making a new user object with the same UID. This fix will reinstate the "deleted" user insted of creating a new user object.