### PR TITLE
Fix lambda block on shrine initializer

### DIFF
--- a/config/initializers/shrine.rb
+++ b/config/initializers/shrine.rb
@@ -29,10 +29,10 @@ if Rails.env.production? || ENV['UPLOAD_TO_S3']
   if ENV['S3_MULTI_TENANCY']
     bucket_suffix = ENV['AWS_BUCKET_SUFFIX']
 
-    Shrine.plugin :default_storage, store: lambda do |_record, _name|
+    Shrine.plugin :default_storage, store: lambda { |_record, _name|
       tenant_name = Apartment::Tenant.current
       :"store_#{tenant_name}"
-    end
+    }
 
     Shrine.storage(/store_(\w+)/) do |match|
       bucket_name = "#{match[1]}-#{bucket_suffix}"


### PR DESCRIPTION
@nakedsushi I think you changed this line from the original implementation https://github.com/ProjectResound/resound-api/pull/19/files#diff-cf5459b42208ed8b3899ae9f7cddbefbR29

because of rubocop, but I don't know why, if we use `lambda do ... end` at this part, we got the following error: `ArgumentError: tried to create Proc object without a block`, so I changed it to use `{}`