### PR TITLE
Pass tenant to AudioProcesssing job

### DIFF
--- a/app/controllers/api/v1/audios_controller.rb
+++ b/app/controllers/api/v1/audios_controller.rb
@@ -125,7 +125,8 @@ module Api::V1
           identifier: params[:flowIdentifier],
           filename: params[:flowFilename],
           title: params[:title],
-          contributors: contributors
+          contributors: contributors,
+          tenant: Apartment::Tenant.current
         )
       end
       DeleteOldFiles.perform_later

--- a/spec/requests/audios_controller_spec.rb
+++ b/spec/requests/audios_controller_spec.rb
@@ -53,7 +53,7 @@ describe Api::V1::AudiosController do
 
       filename = 'lalala.wav'
 
-      it 'enqueues a job and creates a new audio object' do
+      it 'enqueues a job with correct params and creates a new audio object' do
         expect do
           post AUDIO_API_ENDPOINT, params: { file: file,
                                              flowTotalChunks: 2,
@@ -61,7 +61,13 @@ describe Api::V1::AudiosController do
                                              flowFilename: filename,
                                              title: 'lalad',
                                              contributors: 'ben stein' }
-        end.to have_enqueued_job(AudioProcessing)
+        end.to have_enqueued_job(AudioProcessing).with(
+          identifier: "123-lalala1",
+          filename: "lalala.wav",
+          title: "lalad",
+          contributors: "ben stein",
+          tenant: "public"
+        )
 
         audio = Audio.by_filename(filename).first
 

--- a/spec/requests/audios_controller_spec.rb
+++ b/spec/requests/audios_controller_spec.rb
@@ -62,11 +62,11 @@ describe Api::V1::AudiosController do
                                              title: 'lalad',
                                              contributors: 'ben stein' }
         end.to have_enqueued_job(AudioProcessing).with(
-          identifier: "123-lalala1",
-          filename: "lalala.wav",
-          title: "lalad",
-          contributors: "ben stein",
-          tenant: "public"
+          identifier: '123-lalala1',
+          filename: 'lalala.wav',
+          title: 'lalad',
+          contributors: 'ben stein',
+          tenant: 'public'
         )
 
         audio = Audio.by_filename(filename).first


### PR DESCRIPTION
@nakedsushi I don't know how, but this was missing, maybe when you were merging this with rubocop changes some conflict happened and this part got removed by accident.

I also added a test to ensure the tenant is always passed to the job.