### PR TITLE
Fix bug where authentication is needed to view the embeddable audio p…

### DIFF
--- a/app/controllers/api/v1/audios_controller.rb
+++ b/app/controllers/api/v1/audios_controller.rb
@@ -8,6 +8,7 @@ module Api::V1
     include Secured
 
     before_action :find_audio, only: %i[show update destroy]
+    skip_before_action :authenticate_request!, only: [:show]
 
     PER_PAGE = 25
 


### PR DESCRIPTION
…layer

In this pull request, I added an exception where a user can retrieve the audio data without being authenticated.

The reason that I added this was because I removed the embeddable audio player's audio file, contributors, and title from the query params (since it shouldn't be editable through query params). Therefore, I had to make a `fetch` call with the audio id to retrieve the audio data. 

However, this wasn't possible unless the user is authenticated and since users shouldn't have to login to view the embeddable audio player I added an exception as long as the data is being retrieved and not updated and destroyed, then the user can require it without authentication.

Here's also the link to the PR where I removed the audio file, contributor, and title from the query params and made a fetch call to grab the audio data:
https://github.com/ProjectResound/store-upload/pull/45