### PR TITLE
Cache/waveform

### DIFF
--- a/app/controllers/api/v1/audios_controller.rb
+++ b/app/controllers/api/v1/audios_controller.rb
@@ -148,13 +148,14 @@ module Api::V1
     def update
       if @audio && request.body
         payload = JSON.parse(request.body.read)
-        @audio.title = payload['title'] if payload['title']
+        attributes = ['title', 'tags', 'peaks']
+        attributes.each do |attribute|
+          @audio.send("#{attribute}=", payload[attribute]) if payload[attribute]
+        end
         if payload['contributors']
           @audio.contributors =
             Contributor.parse_and_process(payload['contributors'])
         end
-        @audio.tags = payload['tags'] if payload['tags']
-        @audio.peaks = payload['peaks'] if payload['peaks']
         @audio.save!
         AudioUpdating.perform_later(@audio.id)
         render json: @audio

--- a/app/controllers/api/v1/audios_controller.rb
+++ b/app/controllers/api/v1/audios_controller.rb
@@ -154,6 +154,7 @@ module Api::V1
             Contributor.parse_and_process(payload['contributors'])
         end
         @audio.tags = payload['tags'] if payload['tags']
+        @audio.peaks = payload['peaks'] if payload['peaks']
         @audio.save!
         AudioUpdating.perform_later(@audio.id)
         render json: @audio

--- a/app/controllers/api/v1/audios_controller.rb
+++ b/app/controllers/api/v1/audios_controller.rb
@@ -148,7 +148,7 @@ module Api::V1
     def update
       if @audio && request.body
         payload = JSON.parse(request.body.read)
-        attributes = ['title', 'tags', 'peaks']
+        attributes = %w[title tags peaks]
         attributes.each do |attribute|
           @audio.send("#{attribute}=", payload[attribute]) if payload[attribute]
         end

--- a/app/serializers/audio_serializer.rb
+++ b/app/serializers/audio_serializer.rb
@@ -10,7 +10,8 @@ class AudioSerializer < ActiveModel::Serializer
              :tags,
              :contributors,
              :uploader,
-             :files
+             :files,
+             :peaks
 
   def uploader
     user = User.find_by_uid(object.uploader_id)

--- a/db/migrate/20170722203820_create_audio_search_engines.rb
+++ b/db/migrate/20170722203820_create_audio_search_engines.rb
@@ -1,5 +1,7 @@
 class CreateAudioSearchEngines < ActiveRecord::Migration[5.0]
   def change
+    return if ActiveRecord::Base.connection.view_exists? 'audio_search_engines'
+
     if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "postgresql"
       create_view :audio_search_engines
     elsif ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
@@ -16,5 +18,6 @@ FROM audios
 JOIN users ON audios.uploader_id = users.uid
 ;"
     end
+
   end
 end

--- a/db/migrate/20190522203943_add_peaks_to_audio.rb
+++ b/db/migrate/20190522203943_add_peaks_to_audio.rb
@@ -1,0 +1,5 @@
+class AddPeaksToAudio < ActiveRecord::Migration[5.0]
+  def change
+    add_column :audios, :peaks, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170722203820) do
+ActiveRecord::Schema.define(version: 20190522203943) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define(version: 20170722203820) do
     t.datetime "updated_at",   null: false
     t.string   "tags"
     t.string   "contributors"
+    t.string   "peaks"
     t.index "to_tsvector('english'::regconfig, (title)::text)", name: "index_audios_on_title", using: :gin
     t.index ["filename"], name: "index_audios_on_filename", unique: true, using: :btree
   end


### PR DESCRIPTION
In this pull request, I allowed peaks to be stored in the audio object in order for the waveform for the embeddable audio player to be cached. I have also reduced the complexity and changed the array syntax for the rubocop test to pass.