### PR TITLE
Fix/wav bug

### DIFF
--- a/app/services/flow_service.rb
+++ b/app/services/flow_service.rb
@@ -25,7 +25,9 @@ class FlowService
     )
     duration = transcoder.duration
 
-    if File.extname(@filename) == '.wav'
+    file_extension = File.extname(@filename).downcase
+
+    if file_extension == '.wav'
       transcoder.transcode(
         output: final_flac_path,
         format: Transcoder::FLAC

--- a/app/services/flow_service.rb
+++ b/app/services/flow_service.rb
@@ -24,7 +24,6 @@ class FlowService
       contributor: @contributor
     )
     duration = transcoder.duration
-
     file_extension = File.extname(@filename).downcase
 
     if file_extension == '.wav'


### PR DESCRIPTION
In this pull request, I tested Jay's fix for the bug where `.WAV` files does not get transcoded. It's because the file is unable to pass the if statement since it's only checking if the file ends in `.wav` and not `.WAV`. So the file extension is lowercased so `.WAV` files can be transcoded.

I have tested this locally and on staging and the `.WAV` files are able to be transcoded.